### PR TITLE
[Fixed UnicodeDecodeError]UnicodeDecodeError: 'utf-8' codec can't decode byte 0xca in position 97: invalid continuation byte

### DIFF
--- a/QA_data/QA_test.py
+++ b/QA_data/QA_test.py
@@ -9,7 +9,7 @@ conn = sqlite3.connect('./QA_data/QA.db')
 
 cursor = conn.cursor()
 stop_words = []
-with open('./QA_data/stop_words.txt') as f:
+with open('./QA_data/stop_words.txt', encoding='gbk') as f:
     for line in f.readlines():
         stop_words.append(line.strip('\n'))
 


### PR DESCRIPTION
Fixed by specify encoding while reading stop-words file

**Environment**
MacOS 10.13
Python 3.6
iTerm2 3.2.9

**Reproducing steps**
* clone this project
* pip install dependencies
* run `python main.py chat`

**Error detail**
```
Traceback (most recent call last):
  File "main.py", line 6, in <module>
    from QA_data import QA_test
  File "/Users/leo/Project/python/Chinese-Chatbot-PyTorch-Implementation/QA_data/QA_test.py", line 13, in <module>
    for line in f.readlines():
  File "/Users/leo/.pyenv/versions/3.6.4/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xca in position 97: invalid continuation byte
```